### PR TITLE
Add configuration for iotcentral deep links

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -22,6 +22,12 @@
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
+        <intent-filter android:autoVerify="true">
+            <action android:name="android.intent.action.VIEW" />
+            <category android:name="android.intent.category.DEFAULT" />
+            <category android:name="android.intent.category.BROWSABLE" />
+            <data android:scheme="https" android:host="apps.azureiotcentral.com" android:path="/phone-as-device-app-store" />
+        </intent-filter>
       </activity>
     </application>
 </manifest>

--- a/ios/IoT_PnP.xcodeproj/project.pbxproj
+++ b/ios/IoT_PnP.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		3B4392A12AC88292D35C810B /* Pods-IoT_PnP.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IoT_PnP.debug.xcconfig"; path = "Target Support Files/Pods-IoT_PnP/Pods-IoT_PnP.debug.xcconfig"; sourceTree = "<group>"; };
 		4A45C58025FFD5B0005A8543 /* Charts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Charts.swift; sourceTree = "<group>"; };
 		4A45C58425FFD5C6005A8543 /* IoT_PnP-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "IoT_PnP-Bridging-Header.h"; sourceTree = "<group>"; };
+		4B55BE3B2852645300CD9D59 /* IoT_PnP.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = IoT_PnP.entitlements; path = IoT_PnP/IoT_PnP.entitlements; sourceTree = "<group>"; };
 		5709B34CF0A7D63546082F79 /* Pods-IoT_PnP.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IoT_PnP.release.xcconfig"; path = "Target Support Files/Pods-IoT_PnP/Pods-IoT_PnP.release.xcconfig"; sourceTree = "<group>"; };
 		5B7EB9410499542E8C5724F5 /* Pods-IoT_PnP-IoT_PnPTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-IoT_PnP-IoT_PnPTests.debug.xcconfig"; path = "Target Support Files/Pods-IoT_PnP-IoT_PnPTests/Pods-IoT_PnP-IoT_PnPTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5DCACB8F33CDC322A6C60F78 /* libPods-IoT_PnP.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-IoT_PnP.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -89,6 +90,7 @@
 		13B07FAE1A68108700A75B9A /* IoT_PnP */ = {
 			isa = PBXGroup;
 			children = (
+				4B55BE3B2852645300CD9D59 /* IoT_PnP.entitlements */,
 				13B07FAF1A68108700A75B9A /* AppDelegate.h */,
 				13B07FB01A68108700A75B9A /* AppDelegate.mm */,
 				13B07FB51A68108700A75B9A /* Images.xcassets */,
@@ -491,6 +493,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = IoT_PnP/IoT_PnP.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -522,6 +525,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = IoT_PnP/IoT_PnP.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;

--- a/ios/IoT_PnP/IoT_PnP.entitlements
+++ b/ios/IoT_PnP/IoT_PnP.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple/DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+        <string>applinks:apps.azureiotcentral.com</string>
+    </array>
+</dict>
+</plist>


### PR DESCRIPTION
Both Android and iOS offer capabilities to link a website to an app and be able to open it when certain links are open within the device. This PR adds the configuration for linking both apps with IoT Central. There's another part of the puzzle here that is being done in the server side and deployed to central.

Reference: 

Android: https://developer.android.com/training/app-links/deep-linking
iOS: https://developer.apple.com/documentation/Xcode/supporting-associated-domains