### PR TITLE
Normalize accelerometer data to m/s^2

### DIFF
--- a/src/sensors/internal.ts
+++ b/src/sensors/internal.ts
@@ -13,8 +13,8 @@ export interface ISensor extends EventEmitter {
 
 export type Vector = {x: number; y: number; z: number};
 
-export function getRandom(): number {
-  return Math.round(Math.random() * 20) - 10;
+export function getRandom(min: number = -10, max: number = 10): number {
+  return Math.round(Math.random() * (max - min)) + min;
 }
 
 export const AVAILABLE_SENSORS = {


### PR DESCRIPTION
Both Android and iOS use different units for their accelerometer values. This PR adds some normalization code to make sure the device ends up sending data in the same unit and update the simulated value to be more realistic to this unit.